### PR TITLE
Define raw_input() for Python 3

### DIFF
--- a/badpdf.py
+++ b/badpdf.py
@@ -19,9 +19,9 @@ import subprocess
 """
 
 try:
-    raw_input          # Python 2
+    input = raw_input  # Python 2
 except NameError:
-    raw_input = input  # Python 3
+    pass               # Python 3
 
 responder = '/usr/bin/responder'
 interface = 'eth0'
@@ -124,11 +124,11 @@ if __name__ == "__main__":
 
         else:
             print("Responder not found..")
-            responder = raw_input("Please enter responder path (Default /usr/bin/responder): \n")
+            responder = input("Please enter responder path (Default /usr/bin/responder): \n")
 
-        host = raw_input("Please enter Bad-PDF host IP: \n")
-        filename = raw_input("Please enter output file name: \n")
-        interface = raw_input("Please enter the interface name to listen(Default eth0): \n")
+        host = input("Please enter Bad-PDF host IP: \n")
+        filename = input("Please enter output file name: \n")
+        interface = input("Please enter the interface name to listen(Default eth0): \n")
 
         create_malpdf(filename, '\\' + '\\' + host + '\\')
 

--- a/badpdf.py
+++ b/badpdf.py
@@ -18,6 +18,11 @@ import subprocess
 ====================================================================================================================        
 """
 
+try:
+    raw_input          # Python 2
+except NameError:
+    raw_input = input  # Python 3
+
 responder = '/usr/bin/responder'
 interface = 'eth0'
 RED, WHITE, CYAN, GREEN, END = '\033[91m', '\33[46m', '\033[36m', '\033[1;32m', '\033[0m'


### PR DESCRIPTION
__raw_input()__ was removed in Python 3 in favor of __input()__.